### PR TITLE
Remove internal artifact names from public ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@ runtime/
 design-qa.md
 docs/audits/
 tests/contracts/
-docs/enterprise-remediation-executable-spec-v2.md
-docs/open-source-absorption-and-language-decision.md
-docs/superpowers/plans/2026-08-09-enterprise-remediation-slice-0-baseline.md
 *.db
 *.db-journal
 *.db-shm


### PR DESCRIPTION
Removes three exact internal planning-document names that were left in the public .gitignore. The underlying documents were never present in the public repository. This closes the final anonymous-clone metadata finding without changing runtime code.