### PR TITLE
docs: update repository owner links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 可自托管的员工入职、制度学习与考试平台。CohortHarbor 把员工账号、入职资料、制度版本、在线学习、考试任务、通知邮件和私有文件保护放在一个全栈应用中，适合内部部署、二次开发和开源协作。
 
-[![CI](https://github.com/ailsazhang94-jpg/cohort-harbor/actions/workflows/ci.yml/badge.svg)](https://github.com/ailsazhang94-jpg/cohort-harbor/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/ailsazhang94-jpg/cohort-harbor/actions/workflows/codeql.yml/badge.svg)](https://github.com/ailsazhang94-jpg/cohort-harbor/actions/workflows/codeql.yml)
+[![CI](https://github.com/lantingzhang1119/cohort-harbor/actions/workflows/ci.yml/badge.svg)](https://github.com/lantingzhang1119/cohort-harbor/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/lantingzhang1119/cohort-harbor/actions/workflows/codeql.yml/badge.svg)](https://github.com/lantingzhang1119/cohort-harbor/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-0f766e.svg)](LICENSE)
 
 > 当前仓库提供的是可公开使用的通用代码与 mock 数据。仓库不包含真实员工、生产数据库、企业制度原件或 SMTP/API 密钥；部署时请通过环境变量和私有存储注入组织自己的数据。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security fixes are applied to the latest commit on `main`. Until the first tagge
 
 ## Reporting a vulnerability
 
-Use [GitHub private vulnerability reporting](https://github.com/ailsazhang94-jpg/cohort-harbor/security/advisories/new). Do not open a public issue for a suspected vulnerability.
+Use [GitHub private vulnerability reporting](https://github.com/lantingzhang1119/cohort-harbor/security/advisories/new). Do not open a public issue for a suspected vulnerability.
 
 Include the affected route or component, prerequisites, impact, a minimal reproduction using synthetic data, and any suggested mitigation. Do not send live credentials, `.env` files, employee records, private documents, production database copies, SMTP transcripts, or access tokens.
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ailsazhang94-jpg/cohort-harbor.git"
+    "url": "git+https://github.com/lantingzhang1119/cohort-harbor.git"
   },
   "bugs": {
-    "url": "https://github.com/ailsazhang94-jpg/cohort-harbor/issues"
+    "url": "https://github.com/lantingzhang1119/cohort-harbor/issues"
   },
-  "homepage": "https://github.com/ailsazhang94-jpg/cohort-harbor#readme",
+  "homepage": "https://github.com/lantingzhang1119/cohort-harbor#readme",
   "type": "module",
   "packageManager": "pnpm@11.16.0",
   "engines": {

--- a/sbom.spdx.json
+++ b/sbom.spdx.json
@@ -29,7 +29,7 @@
       "licenseDeclared": "MIT",
       "copyrightText": "NOASSERTION",
       "description": "Self-hosted employee onboarding, policy learning, and assessment platform.",
-      "homepage": "git+https://github.com/ailsazhang94-jpg/cohort-harbor.git"
+      "homepage": "git+https://github.com/lantingzhang1119/cohort-harbor.git"
     },
     {
       "SPDXID": "SPDXRef-Package--playwright-test-1.61.1-0",


### PR DESCRIPTION
## Summary

- update README workflow badges to the new owner
- update vulnerability reporting and package metadata URLs
- update the SPDX SBOM homepage

## Verification

- Node 24.14.0: 156 test files passed, 1160 tests passed
- ESLint passed
- TypeScript typecheck passed
- no tracked references to the former owner remain